### PR TITLE
Fixed some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ In case you wanna *use* the python scripts, you have to at least install python 
 - ~~requests~~
 - ~~numpy~~
 - ~~datatable~~
+- coverage (for development/testing)
 
 In case you wanna build the scripts into a onefile executabe
 - nuitka based - supported (see create_nuitka_exe.bat on windows)

--- a/export_html.py
+++ b/export_html.py
@@ -90,9 +90,10 @@ def generateHTML(
     tr_tds_rows = ""
     for fn, fp, id, line, column, detection in curs:
         ii = db.get_issue(id)
-        assert (
-            ii is not None
-        ), f"ERRRO: Log includes detected issue id but we have no information about it.\n{id} {fp} line"
+        if ii is None:
+            raise ValueError(
+                f"ERROR: Log includes detected issue id but we have no information about it.\n{id} {fp} line"
+            )
         detection = detection.replace("potential affected", "p")
         detection = detection.replace("affected", "d")
         raw = map(

--- a/export_xlsx.py
+++ b/export_xlsx.py
@@ -326,7 +326,6 @@ def _addOneSheet(
     img.width = 48
     img.height = 48
     ws.add_image(img)
-    openpyxl.comments.Comment
 
     ws.row_dimensions[1].height = 40
     ws["D1"].alignment = Alignment(vertical="center")
@@ -363,7 +362,6 @@ def generateExcel(
     img.width = 64
     img.height = 64
     ws.add_image(img)
-    openpyxl.comments.Comment
 
     ws.row_dimensions[1].height = 54
     ws["B1"].alignment = Alignment(vertical="center")

--- a/issuedb.py
+++ b/issuedb.py
@@ -123,7 +123,7 @@ class IssueDB(object):
         inspector_version: str,
         xmlfile: Path,
         relnotefile: Path,
-        verbose: False,
+        verbose: bool = False,
     ):
 
         self.compiler_version = compiler_version
@@ -137,8 +137,9 @@ class IssueDB(object):
         self._create_tables()
 
     def __del__(self):
-        if self.conn:
-            self.conn.close()
+        conn = getattr(self, "conn", None)
+        if conn:
+            conn.close()
 
     def _create_tables(self):
         # create ReleaseNoteIssue table
@@ -202,7 +203,7 @@ class IssueDB(object):
             int: return number of inserted release note issues / inspector detectors
         """
 
-        input = ""
+        content = ""
 
         if self.relnotefile is not None:
             if self.verbose:
@@ -212,16 +213,16 @@ class IssueDB(object):
                     + "'"
                 )
             with open(self.relnotefile) as fp:
-                input = fp.read()
+                content = fp.read()
 
-        if not input:
+        if not content:
             if self.verbose:
                 print("ERROR: No input in passed release notes file!")
             return 0
         if self.verbose:
             print("INFO: Import issue information")
 
-        soup = BeautifulSoup(input, "html.parser")
+        soup = BeautifulSoup(content, "html.parser")
         title_tag = soup.title
         if title_tag is None:
             raise ValueError(
@@ -305,7 +306,7 @@ class IssueDB(object):
         Note: XML export from portal includes no 'closed' ticket information = won't fix or dublicated
         """
 
-        input = ""
+        content = ""
 
         if self.xmlfile is not None:
             if self.verbose:
@@ -315,16 +316,16 @@ class IssueDB(object):
                     + "'"
                 )
             with open(self.xmlfile, encoding="utf-8") as fp:
-                input = fp.read()
+                content = fp.read()
 
-        if not input:
+        if not content:
             if self.verbose:
                 print("ERROR: No input in passed XML issue portal export file file!")
             return 0
         if self.verbose:
             print("INFO: Import detector / issue information.")
 
-        soup = BeautifulSoup(input, "xml")
+        soup = BeautifulSoup(content, "xml")
         pv_tag = soup.find("product_version")
         if pv_tag is None:
             raise ValueError("ERROR: XML file is missing required <product_version> tag")
@@ -396,7 +397,7 @@ class IssueDB(object):
 
     def get_list_of_detectable_issues(self) -> list:
         self.cur.execute("SELECT id FROM ReleaseNoteIssues ORDER BY id")
-        return [id[0] for (id) in self.cur.fetchall()]
+        return [row[0] for row in self.cur.fetchall()]
 
     def get_portal_issue(self, id: str) -> PortalIssue:
         """Search issue id in passed dataframe.

--- a/parse.py
+++ b/parse.py
@@ -154,8 +154,9 @@ class LogDB(object):
         self._create_tables()
 
     def __del__(self):
-        if self.conn:
-            self.conn.close()
+        conn = getattr(self, "conn", None)
+        if conn:
+            conn.close()
 
     def _create_tables(self):
         cols = ",".join(
@@ -233,7 +234,7 @@ class LogDB(object):
         if not lines:
             if self.verbose:
                 print("ERROR: No input in passed log file!")
-            return 0
+            return
 
         if self.verbose:
             print("INFO: Parse log file information!")
@@ -278,8 +279,7 @@ class LogDB(object):
                         "d;-"  # normal detection, no assembly comparison available
                     )
                 else:
-                    detectiontype = ("?,?")
-                    assert False, "ERROR: Script is wrong - no unclear result possible!"
+                    raise RuntimeError("ERROR: Script is wrong - no unclear result possible!")
                     
                 issueid = match.group("issueid").strip()
                 extension = match.group("extension").strip()

--- a/pip_dependencies.bat
+++ b/pip_dependencies.bat
@@ -2,3 +2,4 @@ pip3 install beautifulsoup4
 pip3 install lxml
 pip3 install openpyxl
 pip3 install Pillow
+pip3 install coverage


### PR DESCRIPTION
| File | Issue | Fix |
|------|-------|-----|
| `issuedb.py` | `verbose: False` — wrong annotation, parameter had no default value | Changed to `verbose: bool = False` |
| `issuedb.py` | `__del__` crashes at interpreter shutdown if `conn` was already garbage-collected | Changed to `getattr(self, "conn", None)` |
| `issuedb.py` | Variables named `input` in `import_release_note` / `import_xml_file` shadow the built-in `input()` | Renamed to `content` |
| `issuedb.py` | `get_list_of_detectable_issues`: confusing `[id[0] for (id) in ...]` pattern, also shadows built-in `id` | Changed to `[row[0] for row in ...]` |
| `parse.py` | `parse_log_file` declared `-> None` but two early-exit paths returned `0` | Changed to bare `return` |
| `parse.py` | `assert False, "..."` — silently disabled when Python runs with the `-O` flag | Changed to `raise RuntimeError(...)` |
| `parse.py` | `__del__` fragile attribute access at interpreter shutdown | Changed to `getattr(self, "conn", None)` |
| `export_html.py` | `assert (ii is not None)` — disabled by `-O`, also contained a typo (`"ERRRO"`) | Changed to `raise ValueError(...)` |
| `export_xlsx.py` | Two standalone `openpyxl.comments.Comment` expressions — dead code with no effect | Removed |
| pip_dependencies.bat, readme.md| coverage missing | added coverage